### PR TITLE
Exit fast

### DIFF
--- a/install/__init__.py
+++ b/install/__init__.py
@@ -38,11 +38,14 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
         install_options: Optional arbitary list of install options to pass to pip install
     """
     # exit fast if pkg already installed
-    try:
-        importlib.import_module(pkg)
-        return
-    except ModuleNotFoundError:
-        ...
+    if sys.version[0] == '3':
+        try:
+            importlib.import_module(pkg)
+            return
+        except ModuleNotFoundError:
+            ...
+        except Exception:
+            ...
 
     if not _check_pip(): _get_pip()
 

--- a/install/__init__.py
+++ b/install/__init__.py
@@ -5,11 +5,11 @@ import subprocess
 import sys
 import os
 import tempfile
+import importlib
 
 if sys.version[0] == '3':
     import urllib.request as url
     from shlex import quote
-    import importlib
 else:
     import urllib as url
     from pipes import quote
@@ -38,14 +38,13 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
         install_options: Optional arbitary list of install options to pass to pip install
     """
     # exit fast if pkg already installed
-    if sys.version[0] == '3':
-        try:
-            importlib.import_module(pkg)
-            return
-        except ModuleNotFoundError:
-            pass
-        except Exception:
-            psas
+    try:
+        importlib.import_module(pkg)
+        return
+    except ModuleNotFoundError:
+        pass
+    except Exception:
+        pass
 
     if not _check_pip(): _get_pip()
 
@@ -79,4 +78,3 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
     cmd.append(pkg)
 
     subprocess.check_call(cmd)
-

--- a/install/__init__.py
+++ b/install/__init__.py
@@ -3,9 +3,11 @@ import subprocess
 import sys
 import os
 import tempfile
+
 if sys.version[0] == '3':
     import urllib.request as url
     from shlex import quote
+    import importlib
 else:
     import urllib as url
     from pipes import quote
@@ -33,6 +35,13 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
         pip_options: Optional arbitary list of global options to pass to pip 
         install_options: Optional arbitary list of install options to pass to pip install
     """
+    # exit fast if pkg already installed 
+    try:
+        importlib.import_module(pkg)
+        return
+    except ModuleNotFoundError:
+        ...
+        
     if not _check_pip(): _get_pip()
 
     cmd = [sys.executable, '-m', 'pip']

--- a/install/__init__.py
+++ b/install/__init__.py
@@ -43,9 +43,9 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
             importlib.import_module(pkg)
             return
         except ModuleNotFoundError:
-            ...
+            pass
         except Exception:
-            ...
+            psas
 
     if not _check_pip(): _get_pip()
 

--- a/install/__init__.py
+++ b/install/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+__version__ = "1.3.5"
+
 import subprocess
 import sys
 import os
@@ -32,20 +34,20 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
         pkg: Name of the package or requirements.txt file as a string, you can also use version specifiers like requests==1.2.3
         use_pep517: Optional boolean to force --use-pep517/--no-use-pep517
         requirements: Optional boolean if a requirements.txt was specified
-        pip_options: Optional arbitary list of global options to pass to pip 
+        pip_options: Optional arbitary list of global options to pass to pip
         install_options: Optional arbitary list of install options to pass to pip install
     """
-    # exit fast if pkg already installed 
+    # exit fast if pkg already installed
     try:
         importlib.import_module(pkg)
         return
     except ModuleNotFoundError:
         ...
-        
+
     if not _check_pip(): _get_pip()
 
     cmd = [sys.executable, '-m', 'pip']
-    
+
     if pip_options:
         if isinstance(pip_options, list):
             options = [quote(option) for option in pip_options]
@@ -60,7 +62,7 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
             options = [quote(option) for option in install_options]
             cmd.extend(options)
         else:
-            raise TypeError('install_options passed to install must be a list') 
+            raise TypeError('install_options passed to install must be a list')
 
     if use_pep517 is True:
         cmd.append('--use-pep517')
@@ -69,7 +71,7 @@ def install(pkg, use_pep517=None, requirements=None, pip_options=None, install_o
 
     if requirements:
         cmd.append('-r')
-    
+
     pkg = quote(pkg)
     cmd.append(pkg)
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 
 setup(
     name = "install",
-    version = "1.3.4",
+    version = "1.3.5",
     author = "Eugene Kolo",
     author_email = "eugene@kolobyte.com",
     description = "Install packages from within code",


### PR DESCRIPTION
Hi.

I just added a few lines in the beginning of  `install.install`.

Purpose: Repeated runs of `install.install(pkg)` will take much less time. The main use is in `colab`. 

I've beeb fooling around a bit with colab and come to need a similar package as your `install`. I did a serch on pypi and found your `install` before I started writing my own.

`install` fits my need well except it approximatedly takes `3` secons for each package even when the pakage is already installed.

Hence the `pr`. Please take a look and merge it, or not, as you see it fit.
